### PR TITLE
fix(tls): trust corporate proxy CAs for outbound HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Corporate TLS trust bootstrap (`internal/tls`): installs a process-wide
+  default `SSLContext` that adds corporate proxy root CAs (Zscaler, etc.)
+  to the platform truststore, so outbound HTTPS from every provider and
+  channel works behind a TLS-intercepting proxy. CAs are read from the
+  `vis.ca-bundle` JVM property, the `ZSCALER_CA_BUNDLE` /
+  `NODE_EXTRA_CA_CERTS` / `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` /
+  `CURL_CA_BUNDLE` / `AWS_CA_BUNDLE` env vars, and the `~/.vis/certs/`
+  drop-in directory. Verification is never disabled; unknown
+  certificates still fail.
 - Extension system with global registry, topo-sort, hot-reload
 - `:ext/nudge-fn` for per-iteration system nudges from extensions
 - `:ext/requires` for extension dependency declaration

--- a/src/com/blockether/vis/internal/main.clj
+++ b/src/com/blockether/vis/internal/main.clj
@@ -47,6 +47,7 @@
    [com.blockether.vis.internal.provider-limits :as provider-limits]
    [com.blockether.vis.internal.registry :as registry]
    [com.blockether.vis.internal.render :as render]
+   [com.blockether.vis.internal.tls :as tls]
    [taoensso.telemere :as tel]))
 
 ;; =============================================================================
@@ -2785,6 +2786,13 @@
       ;; (or set VIS_DEBUG=1).
       (timed-startup! measure? "configure-logging"
         #(configure-logging! args))
+      ;; Trust corporate TLS-intercepting proxies (Zscaler, etc.) before any
+      ;; provider/channel opens an HTTPS connection (turns happen well after
+      ;; this). A single default SSLContext covers every java.net.http /
+      ;; babashka http-client in the process. No-op without a corporate CA.
+      ;; Placed after logging so the install summary is captured.
+      (timed-startup! measure? "install-tls-trust"
+        #(tls/install!))
       (cond
         (root-help-request? args)
         (println (commandline/render-tree (root-command)))

--- a/src/com/blockether/vis/internal/tls.clj
+++ b/src/com/blockether/vis/internal/tls.clj
@@ -1,0 +1,190 @@
+(ns com.blockether.vis.internal.tls
+  "Outbound HTTPS trust bootstrap for corporate TLS-intercepting proxies.
+
+   Zscaler (and similar proxies) re-sign every upstream certificate with
+   a private root CA that the JVM truststore does not ship. Every
+   provider/channel HTTP client in Vis - anthropic, openai, copilot,
+   zai, telegram, exa, foundation-search, and the TUI provider - is
+   built on `java.net.http.HttpClient` (directly or via babashka
+   http-client). All of those fall back to `SSLContext/getDefault` when
+   no explicit context is supplied, so a single `SSLContext/setDefault`
+   at startup teaches the whole process to trust the extra CA(s) with no
+   per-client wiring.
+
+   We never DISABLE verification. We ADD the corporate root(s) to the
+   platform defaults through a composite `X509TrustManager`: the
+   platform trust manager is consulted first and the extra-CA trust
+   manager only as a fallback, so genuinely-unknown certificates still
+   fail the handshake.
+
+   CA sources, in order, de-duplicated by absolute path:
+     1. JVM property `vis.ca-bundle`
+     2. env vars: ZSCALER_CA_BUNDLE, NODE_EXTRA_CA_CERTS,
+        REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CURL_CA_BUNDLE, AWS_CA_BUNDLE
+     3. drop-in dir `~/.vis/certs/` (*.pem, *.crt, *.cer)
+
+   When no extra CA is found the function is a no-op and the JVM keeps
+   its stock truststore."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [taoensso.telemere :as tel])
+  (:import
+   (java.io File)
+   (java.security KeyStore)
+   (java.security.cert CertificateFactory X509Certificate)
+   (javax.net.ssl SSLContext TrustManager TrustManagerFactory X509TrustManager)))
+
+(def ^:private ca-env-vars
+  ["ZSCALER_CA_BUNDLE" "NODE_EXTRA_CA_CERTS" "REQUESTS_CA_BUNDLE"
+   "SSL_CERT_FILE" "CURL_CA_BUNDLE" "AWS_CA_BUNDLE"])
+
+(def ^:private cert-extensions #{"pem" "crt" "cer"})
+
+(defonce ^:private installed (atom false))
+
+(defn certs-dir
+  "Drop-in directory for corporate CA certificates: `~/.vis/certs`."
+  ^File []
+  (io/file (System/getProperty "user.home") ".vis" "certs"))
+
+(defn- readable-file
+  "Coerce `x` to a `File` and return it only when it is a readable file."
+  ^File [x]
+  (when (some? x)
+    (let [s (str/trim (str x))]
+      (when-not (str/blank? s)
+        (let [f (io/file s)]
+          (when (and (.isFile f) (.canRead f)) f))))))
+
+(defn- cert-ext? [^File f]
+  (let [n (str/lower-case (.getName f))
+        i (str/last-index-of n ".")]
+    (and i (contains? cert-extensions (subs n (inc i))))))
+
+(defn- drop-in-files
+  "Readable *.pem/*.crt/*.cer files under `~/.vis/certs`, sorted by name."
+  []
+  (let [dir (certs-dir)]
+    (when (.isDirectory dir)
+      (->> (.listFiles dir)
+        (filter #(and (.isFile ^File %) (.canRead ^File %) (cert-ext? %)))
+        (sort-by #(.getName ^File %))))))
+
+(defn ca-sources
+  "Ordered, de-duplicated seq of readable CA bundle `File`s from JVM
+   property, env vars, and the `~/.vis/certs` drop-in directory."
+  []
+  (let [candidates (concat
+                     [(readable-file (System/getProperty "vis.ca-bundle"))]
+                     (map #(readable-file (System/getenv %)) ca-env-vars)
+                     (drop-in-files))]
+    (->> candidates
+      (remove nil?)
+      (reduce (fn [[seen acc] ^File f]
+                (let [p (.getAbsolutePath f)]
+                  (if (contains? seen p)
+                    [seen acc]
+                    [(conj seen p) (conj acc f)])))
+        [#{} []])
+      second)))
+
+(defn- x509-of
+  "First `X509TrustManager` produced by `tmf`, or nil."
+  ^X509TrustManager [^TrustManagerFactory tmf]
+  (some (fn [^TrustManager tm]
+          (when (instance? X509TrustManager tm) tm))
+    (.getTrustManagers tmf)))
+
+(defn- platform-trust-manager
+  "Platform-default `X509TrustManager` (the stock JVM truststore).
+   Initializing a `TrustManagerFactory` with a nil `KeyStore` loads the
+   JVM's default trust material."
+  ^X509TrustManager []
+  (let [tmf       (TrustManagerFactory/getInstance (TrustManagerFactory/getDefaultAlgorithm))
+        ^KeyStore default-ks nil]
+    (.init tmf default-ks)
+    (x509-of tmf)))
+
+(defn- extra-trust-manager
+  "`X509TrustManager` backed by a keystore loaded from `files`, plus the
+   total count of certificates loaded. Returns `[tm n]` or nil when no
+   certificate could be read."
+  [files]
+  (let [ks (doto (KeyStore/getInstance (KeyStore/getDefaultType))
+             (.load nil nil))
+        cf (CertificateFactory/getInstance "X.509")
+        n  (volatile! 0)]
+    (doseq [^File f files]
+      (try
+        (with-open [in (io/input-stream f)]
+          (doseq [cert (.generateCertificates cf in)]
+            (.setCertificateEntry ks (str "vis-ca-" @n) cert)
+            (vswap! n inc)))
+        (catch Throwable t
+          (tel/log! {:level :warn :id ::ca-load-failed}
+            (str "Skipped unreadable CA bundle " (.getAbsolutePath f) ": " (ex-message t))))))
+    (when (pos? @n)
+      (let [tmf (TrustManagerFactory/getInstance (TrustManagerFactory/getDefaultAlgorithm))]
+        (.init tmf ks)
+        [(x509-of tmf) @n]))))
+
+(defn- composite-trust-manager
+  "Trust manager that accepts a chain trusted by EITHER `platform` or
+   `extra`. Platform is tried first; `extra` is the corporate-CA
+   fallback. Client-auth and accepted-issuers delegate to both."
+  ^X509TrustManager [^X509TrustManager platform ^X509TrustManager extra]
+  (reify X509TrustManager
+    (checkClientTrusted [_ chain auth-type]
+      (.checkClientTrusted platform chain auth-type))
+    (checkServerTrusted [_ chain auth-type]
+      (try
+        (.checkServerTrusted platform chain auth-type)
+        (catch java.security.cert.CertificateException _
+          (.checkServerTrusted extra chain auth-type))))
+    (getAcceptedIssuers [_]
+      (into-array X509Certificate
+        (concat (seq (.getAcceptedIssuers platform))
+          (seq (.getAcceptedIssuers extra)))))))
+
+(defn install!
+  "Install a process-wide default `SSLContext` that trusts the platform
+   CAs plus any corporate root CA(s) discovered via `ca-sources`.
+
+   No-op (returns nil) when no extra CA is found or trust is already
+   installed. Idempotent. Returns a summary map
+   `{:certs n :sources [paths...]}` on success.
+
+   Safe to call early in `-main`: failures are logged and swallowed so a
+   broken CA file can never prevent the process from starting (it just
+   falls back to the stock truststore)."
+  []
+  (when (compare-and-set! installed false true)
+    (try
+      (let [files (ca-sources)]
+        (if (empty? files)
+          (do (tel/log! {:level :debug :id ::no-extra-ca}
+                "No corporate CA bundle found; using platform truststore.")
+            nil)
+          (if-let [[extra n] (extra-trust-manager files)]
+            (let [platform (platform-trust-manager)
+                  ctx      (SSLContext/getInstance "TLS")
+                  paths    (mapv #(.getAbsolutePath ^File %) files)]
+              (.init ctx nil
+                (into-array TrustManager [(composite-trust-manager platform extra)])
+                nil)
+              (SSLContext/setDefault ctx)
+              (tel/log! {:level :info :id ::installed
+                         :data {:certs n :sources paths}}
+                (str "Installed corporate TLS trust: " n " cert(s) from "
+                  (count paths) " source(s)."))
+              {:certs n :sources paths})
+            (do (tel/log! {:level :warn :id ::no-certs-loaded}
+                  "Corporate CA source(s) present but no certificate could be loaded.")
+              nil))))
+      (catch Throwable t
+        ;; Never let trust bootstrap crash startup - fall back to stock truststore.
+        (reset! installed false)
+        (tel/log! {:level :warn :id ::install-failed}
+          (str "Corporate TLS trust bootstrap failed: " (ex-message t)))
+        nil))))

--- a/test/com/blockether/vis/internal/tls_test.clj
+++ b/test/com/blockether/vis/internal/tls_test.clj
@@ -1,0 +1,35 @@
+(ns com.blockether.vis.internal.tls-test
+  "Trust-bootstrap tests.
+
+   These run in CI where no corporate CA is present, so assertions hold
+   both with and without an extra CA on disk: `ca-sources` must always
+   yield readable files, and `install!` must never throw and must be
+   idempotent."
+  (:require
+   [clojure.string :as str]
+   [com.blockether.vis.internal.tls :as tls]
+   [lazytest.core :refer [defdescribe expect it]])
+  (:import
+   (java.io File)))
+
+(defdescribe tls-test
+  (it "resolves the drop-in certs dir under ~/.vis/certs"
+    (let [p (.getPath (tls/certs-dir))]
+      (expect (str/ends-with? p (str File/separator ".vis" File/separator "certs")))))
+
+  (it "ca-sources returns only readable files, de-duplicated by path"
+    (let [files (tls/ca-sources)]
+      (expect (every? #(and (instance? File %) (.isFile ^File %) (.canRead ^File %)) files))
+      (let [paths (map #(.getAbsolutePath ^File %) files)]
+        (expect (= (count paths) (count (distinct paths)))))))
+
+  (it "install! never throws and is idempotent"
+    (let [first-result  (tls/install!)
+          second-result (tls/install!)]
+      ;; First call returns a summary map (CA present) or nil (none found).
+      (expect (or (nil? first-result) (map? first-result)))
+      (when (map? first-result)
+        (expect (pos? (:certs first-result)))
+        (expect (vector? (:sources first-result))))
+      ;; Trust is installed once; a second call is always a no-op.
+      (expect (nil? second-result)))))


### PR DESCRIPTION
## Problem

Behind a TLS-intercepting proxy (Zscaler and similar), every upstream certificate is re-signed by a private root CA that the JVM truststore does not ship. Every outbound HTTPS request from Vis then fails the handshake with:

```
javax.net.ssl.SSLHandshakeException: PKIX path building failed:
  unable to find valid certification path to requested target
```

So no provider or channel can reach its LLM endpoint — `vis channels tui` is unusable on a corporate network.

## Fix

Every HTTP client in Vis is built on `java.net.http.HttpClient` (directly or via babashka http-client) and falls back to `SSLContext/getDefault` when no explicit context is supplied. A single `SSLContext/setDefault` at startup therefore fixes the entire process with no per-client wiring.

New `com.blockether.vis.internal.tls`:

- Builds a **composite** `X509TrustManager` that trusts the platform CAs **plus** corporate root CA(s). The platform trust manager is consulted first and the corporate CA only as a fallback, so **verification is never disabled** and genuinely-unknown certificates still fail the handshake.
- Discovers CAs (de-duplicated by absolute path) from:
  1. `vis.ca-bundle` JVM property
  2. env vars: `ZSCALER_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `AWS_CA_BUNDLE`
  3. drop-in dir `~/.vis/certs/` (`*.pem`, `*.crt`, `*.cer`)
- `install!` is called at the top of `-main` before any HTTPS is opened. It is idempotent and failure-swallowing: a bad CA file can never block startup (it just falls back to the stock truststore). No-op when no corporate CA is configured.

## Testing

- New `tls-test` covers source de-duplication, drop-in dir resolution, and idempotency. Passes.
- Manually verified on a Zscaler network: with the fix, `java.net.http.HttpClient` and babashka http-client both reach `api.anthropic.com` (307 / 403 responses) instead of throwing `PKIX path building failed`.
- `cljfmt` and `clj-kondo` clean on the changed files.