### PR TITLE
feat(providers): surface svar 0.7.56 models

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
   com.blockether/vis-language-python              {:local/root "extensions/languages/vis-language-python"}
   com.blockether/vis-workspace-rift                {:local/root "extensions/workspaces/vis-workspace-rift"}
 
-  com.blockether/svar                             {:mvn/version "0.7.55"}
+  com.blockether/svar                             {:mvn/version "0.7.56"}
   com.blockether/anomaly                          {:mvn/version "1.0.1"}
   org.clojure/tools.deps                          {:mvn/version "0.31.1629"}
   org.commonmark/commonmark                       {:mvn/version "0.29.0"}

--- a/extensions/providers/vis-provider-anthropic/test/com/blockether/vis/ext/provider_anthropic_test.clj
+++ b/extensions/providers/vis-provider-anthropic/test/com/blockether/vis/ext/provider_anthropic_test.clj
@@ -19,12 +19,16 @@
         (expect (= "Anthropic (API Key)" (:provider/label api-provider)))
         (expect (= "claude-opus-4-8"
                    (first (get-in api-provider [:provider/preset :default-models]))))
+        (expect (contains? (set (get-in api-provider [:provider/preset :default-models]))
+                           "claude-fable-5"))
         (expect (nil? (:provider/auth-fn api-provider)))
         (expect (= :anthropic-coding-plan (:provider/id oauth-provider)))
         (expect (= "Anthropic (Claude Subscription)" (:provider/label oauth-provider)))
         (expect (= "https://api.anthropic.com/v1"
                    (get-in oauth-provider [:provider/preset :base-url])))
         (expect (= :anthropic (get-in oauth-provider [:provider/preset :api-style])))
+        (expect (contains? (set (get-in oauth-provider [:provider/preset :default-models]))
+                           "claude-fable-5"))
         (expect (ifn? (:provider/status-fn oauth-provider)))
         (expect (ifn? (:provider/logout-fn oauth-provider)))
         (expect (ifn? (:provider/detect-fn oauth-provider)))

--- a/extensions/providers/vis-provider-github-copilot/src/com/blockether/vis/ext/provider_github_copilot.clj
+++ b/extensions/providers/vis-provider-github-copilot/src/com/blockether/vis/ext/provider_github_copilot.clj
@@ -306,9 +306,9 @@
 
 (def ^:private COPILOT_POLICY_MODELS
   ["claude-haiku-4.5" "claude-sonnet-4" "claude-sonnet-4.5" "claude-sonnet-4.6" "claude-sonnet-5"
-   "claude-opus-4.5" "claude-opus-4.6" "claude-opus-4.7" "claude-opus-4.8" "gpt-5" "gpt-5-mini"
-   "gpt-5.1" "gpt-5.1-codex" "gpt-5.1-codex-max" "gpt-5.1-codex-mini" "gpt-5.2" "gpt-5.2-codex"
-   "gpt-5.3-codex" "gpt-5.4" "gpt-5.4-mini" "gpt-4.1" "gpt-4o" "gemini-2.5-pro"
+   "claude-fable-5" "claude-opus-4.5" "claude-opus-4.6" "claude-opus-4.7" "claude-opus-4.8" "gpt-5"
+   "gpt-5-mini" "gpt-5.1" "gpt-5.1-codex" "gpt-5.1-codex-max" "gpt-5.1-codex-mini" "gpt-5.2"
+   "gpt-5.2-codex" "gpt-5.3-codex" "gpt-5.4" "gpt-5.4-mini" "gpt-4.1" "gpt-4o" "gemini-2.5-pro"
    "gemini-3-flash-preview" "gemini-3-pro-preview" "gemini-3.1-pro-preview" "grok-code-fast-1"])
 
 (defn- valid-copilot-host?

--- a/extensions/providers/vis-provider-github-copilot/test/com/blockether/vis/ext/provider_github_copilot_test.clj
+++ b/extensions/providers/vis-provider-github-copilot/test/com/blockether/vis/ext/provider_github_copilot_test.clj
@@ -40,12 +40,15 @@
       (expect (= "/responses" (get-in individual [:provider/preset :responses-path])))
       ;; Catalog carries both cacheable wires; Gemini/Grok (chat-only) dropped.
       (expect (contains? models "claude-opus-4.8"))
+      (expect (contains? models "claude-fable-5"))
       (expect (contains? models "gpt-5.4"))
       ;; Enterprise serves the SAME curated Claude catalog (dotted models.dev
       ;; ids → native Anthropic /v1/messages wire) so Copilot Enterprise users
       ;; can select Opus/Sonnet/Haiku.
       (expect (contains? (set (get-in enterprise [:provider/preset :default-models]))
                          "claude-opus-4.8"))
+      (expect (contains? (set (get-in enterprise [:provider/preset :default-models]))
+                         "claude-fable-5"))
       (expect (contains? (set (get-in enterprise [:provider/preset :default-models]))
                          "claude-sonnet-4.6"))
       (expect (contains? (set (get-in enterprise [:provider/preset :default-models]))

--- a/extensions/providers/vis-provider-openai-codex/test/com/blockether/vis/ext/provider_openai_codex_test.clj
+++ b/extensions/providers/vis-provider-openai-codex/test/com/blockether/vis/ext/provider_openai_codex_test.clj
@@ -177,7 +177,9 @@
                    (expect (= :openai-codex (:provider/id provider)))
                    (expect (= "OpenAI Codex (ChatGPT OAuth)" (:provider/label provider)))
                    (expect (ifn? (:provider/get-token-fn provider)))
-                   (expect (ifn? (:provider/limits-fn provider))))))
+                   (expect (ifn? (:provider/limits-fn provider)))
+                   (expect (contains? (set (get-in provider [:provider/preset :default-models]))
+                                      "gpt-5.6-sol")))))
 
 (defdescribe codex-extension-settings-test
              (it "does not declare legacy TUI settings metadata"


### PR DESCRIPTION
Bumps vis to svar 0.7.56 so gpt-5.6-sol and claude-fable-5 appear in provider defaults. Also adds claude-fable-5 to Copilot policy enablement and covers OpenAI Codex/Anthropic/Copilot provider defaults in tests.